### PR TITLE
feat(OK-23): 환자 삭제 API 부착 및 환자 상세페이지 스켈리톤 구현, accessToken 갱신 로직 개선

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -41,10 +41,6 @@ export const setAccessToken = (token: string | null) => {
   accessToken = token;
 };
 
-export const setHeaderAccessTokenNull = () => {
-  accessToken = null;
-};
-
 export const setCurrentPathname = (pathname: string) => {
   currentPathname = pathname;
 };

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -20,6 +20,8 @@ const authMiddleware: Middleware = {
 
     if (accessToken) {
       request.headers.set('Authorization', `Bearer ${accessToken}`);
+    } else {
+      request.headers.delete('Authorization');
     }
 
     return request;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -26,7 +26,7 @@ const authMiddleware: Middleware = {
 
     return request;
   },
-  async onResponse({ response }) {
+  onResponse({ response }) {
     if (response.status === 401) {
       if (currentPathname !== '/refresh') {
         useAuthStore.getState().setState('accessToken', undefined);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,12 +2,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { router } from 'expo-router';
 import createClient, { type Middleware } from 'openapi-fetch';
 import { type StorageValue } from 'zustand/middleware';
-import { type IAuthState } from '@/stores/authStore';
+import { useAuthStore, type IAuthState } from '@/stores/authStore';
 import { type paths } from './types';
 
 let accessToken: string | null = null;
 let currentPathname: string = '';
-
 const authMiddleware: Middleware = {
   async onRequest({ request }) {
     const auth = JSON.parse((await AsyncStorage.getItem('useAuthStore')) ?? '') as StorageValue<IAuthState>;
@@ -25,9 +24,10 @@ const authMiddleware: Middleware = {
 
     return request;
   },
-  onResponse({ response }) {
+  async onResponse({ response }) {
     if (response.status === 401) {
       if (currentPathname !== '/refresh') {
+        useAuthStore.getState().setState('accessToken', undefined);
         router.replace('/refresh');
       }
     }
@@ -37,6 +37,10 @@ const authMiddleware: Middleware = {
 
 export const setAccessToken = (token: string | null) => {
   accessToken = token;
+};
+
+export const setHeaderAccessTokenNull = () => {
+  accessToken = null;
 };
 
 export const setCurrentPathname = (pathname: string) => {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -4,1833 +4,1925 @@
  */
 
 export interface paths {
-  '/safe-zone/patients/{patientId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/safe-zone/patients/{patientId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 안전구역 목록 조회 */
+        get: operations["findAllSafeZone"];
+        put?: never;
+        /** 안전구역 설정 */
+        post: operations["registerSafeZone"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** 안전구역 목록 조회 */
-    get: operations['findAllSafeZone'];
-    put?: never;
-    /** 안전구역 설정 */
-    post: operations['registerSafeZone'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/patients/{patientId}/location': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/patients/{patientId}/location": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 환자의 마지막 위치 저장 */
+        post: operations["savePatientLastLocation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 환자의 마지막 위치 저장 */
-    post: operations['savePatientLastLocation'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/patients/search': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/patients/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 전화번호로 환자 검색 */
+        post: operations["searchByPhone"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 전화번호로 환자 검색 */
-    post: operations['searchByPhone'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/patients/registration/caregivers/{caregiverId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/patients/registration/caregivers/{caregiverId}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 보호자 등록 요청 수락
+         * @description jwt 토큰 필요, 수락은 status = ACCEPT, 거절은 status = REJECT
+         */
+        post: operations["acceptCaregiverRegistration"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 보호자 등록 요청 수락
-     * @description jwt 토큰 필요
-     */
-    post: operations['registerCaregiver'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/oauth/refresh-token': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/oauth/refresh-token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 토큰 재발급
+         * @description 리프레시 토큰 앞에 토큰 타입 'Bearer ' 필요
+         */
+        post: operations["reGenerateAccessToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 토큰 재발급
-     * @description 리프레시 토큰 앞에 토큰 타입 'Bearer ' 필요
-     */
-    post: operations['reGenerateAccessToken'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/oauth/kakao': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/oauth/kakao": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 카카오 소셜로그인 */
+        post: operations["kakaoLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 카카오 소셜로그인 */
-    post: operations['kakaoLogin'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/oauth/apple': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/oauth/apple": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 애플 소셜로그인 */
+        post: operations["appleLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 애플 소셜로그인 */
-    post: operations['appleLogin'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/notifications': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 알림 목록 조회 */
+        get: operations["getAllNotifications"];
+        put?: never;
+        /** 알림 전송 */
+        post: operations["pushNotification"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** 알림 목록 조회 */
-    get: operations['getAllNotifications'];
-    put?: never;
-    /** 알림 전송 */
-    post: operations['pushNotification'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/notifications/device-token': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/notifications/device-token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 디바이스 토큰 저장 */
+        post: operations["getDeviceToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 디바이스 토큰 저장 */
-    post: operations['getDeviceToken'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/image/upload': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/image/upload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["uploadImage"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations['uploadImage'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/diaries': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/diaries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 일기 저장 */
+        post: operations["saveDiary"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 일기 저장 */
-    post: operations['saveDiary'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/caregiver/registration/patients/{patientId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/caregiver/registration/patients/{patientId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 환자 등록 요청
+         * @description jwt 토큰 필요
+         */
+        post: operations["registerCaregiver"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * 환자 등록 요청
-     * @description jwt 토큰 필요
-     */
-    post: operations['registerCaregiver_1'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/accounts/sign-up': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/accounts/sign-up": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** 회원가입 */
+        post: operations["signUp"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** 회원가입 */
-    post: operations['signUp'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/accounts': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/accounts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * 회원탈퇴
+         * @description jwt 토큰 필요
+         */
+        delete: operations["deleteAccount"];
+        options?: never;
+        head?: never;
+        /**
+         * 계정 정보 수정
+         * @description jwt 토큰 필요
+         */
+        patch: operations["updateUserInfo"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /**
-     * 회원탈퇴
-     * @description jwt 토큰 필요
-     */
-    delete: operations['deleteAccount'];
-    options?: never;
-    head?: never;
-    /**
-     * 계정 정보 수정
-     * @description jwt 토큰 필요
-     */
-    patch: operations['updateUserInfo'];
-    trace?: never;
-  };
-  '/safe-zone/patients/{patientId}/checking': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/safe-zone/patients/{patientId}/checking": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 안전구역 내 존재 확인 */
+        get: operations["checkSafeZone"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** 안전구역 내 존재 확인 */
-    get: operations['checkSafeZone'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/patients/{patientId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/patients/{patientId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 환자 상세 조회 */
+        get: operations["getPatientDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** 환자 상세 조회 */
-    get: operations['getPatientDetail'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/notifications/{notificationId}/read': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/notifications/{notificationId}/read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 알림 읽음 처리 */
+        get: operations["readNotification"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** 알림 읽음 처리 */
-    get: operations['readNotification'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/district/search': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/district/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 행정 구역 검색
+         * @description jwt 토큰 필요
+         */
+        get: operations["searchDistricts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 행정 구역 검색
-     * @description jwt 토큰 필요
-     */
-    get: operations['searchDistricts'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/district/save-data': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/district/save-data": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 행정구역 데이터 저장
+         * @description 로컬에서 데이터 저장 용도, 배포 서버 사용X
+         */
+        get: operations["processGeoJson"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 행정구역 데이터 저장
-     * @description 로컬에서 데이터 저장 용도, 배포 서버 사용X
-     */
-    get: operations['processGeoJson'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/district/coordinate': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/district/coordinate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 행정 구역 정보 조회
+         * @description jwt 토큰 필요, 좌표 제공
+         */
+        get: operations["getDistrictCoordinate"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 행정 구역 정보 조회
-     * @description jwt 토큰 필요, 좌표 제공
-     */
-    get: operations['getDistrictCoordinate'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/district/check/location/safe-zone': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/district/check/location/safe-zone": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 행정구역 내에 포함 여부 확인
+         * @description jwt 토큰 필요
+         */
+        get: operations["checkLocation"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 행정구역 내에 포함 여부 확인
-     * @description jwt 토큰 필요
-     */
-    get: operations['checkLocation'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/diaries/{diaryId}/patients/{patientId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/diaries/{diaryId}/patients/{patientId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 일기 상세 조회 */
+        get: operations["findDiaryById"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** 일기 상세 조회 */
-    get: operations['findDiaryById'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/diaries/all': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/diaries/all": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 전체 일기 목록 조회
+         * @description 보호자의 경우 환자가 공유 허용한 일기만 조회
+         */
+        get: operations["findAllDiary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 전체 일기 목록 조회
-     * @description 보호자의 경우 환자가 공유 허용한 일기만 조회
-     */
-    get: operations['findAllDiary'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/caregiver/patients/list': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/caregiver/patients/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 환자 목록 조회 */
+        get: operations["getPatientsList"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** 환자 목록 조회 */
-    get: operations['getPatientsList'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/accounts/me': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/caregiver/id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 보호자 Id 조회 */
+        get: operations["getCaregiverId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * 계정 정보 조회
-     * @description jwt 토큰 필요
-     */
-    get: operations['getUserInfo'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/safe-zone/{safeZoneId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/accounts/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 계정 정보 조회
+         * @description jwt 토큰 필요
+         */
+        get: operations["getUserInfo"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** 안전구역 삭제 */
-    delete: operations['deleteSafeZone'];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/diaries/{diaryId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/safe-zone/{safeZoneId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** 안전구역 삭제 */
+        delete: operations["deleteSafeZone"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** 일기 삭제 */
-    delete: operations['deleteDiaryById'];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/diaries/{diaryId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** 일기 삭제 */
+        delete: operations["deleteDiaryById"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/caregiver/patients/{patientId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** 환자 삭제 */
+        delete: operations["deletePatient"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    ErrorResponse: {
-      message?: string;
-      /** Format: int32 */
-      code?: number;
-      /** Format: int32 */
-      status?: number;
+    schemas: {
+        ErrorResponse: {
+            message?: string;
+            /** Format: int32 */
+            code?: number;
+            /** Format: int32 */
+            status?: number;
+        };
+        ResponseDtoLong: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            /** Format: int64 */
+            data?: number;
+        };
+        LocationRequestDto: {
+            latitude?: string;
+            longitude?: string;
+        };
+        ResponseDtoString: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: string;
+        };
+        Phone: {
+            phoneNumber?: string;
+        };
+        ResponseDtoListPhone: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["Phone"][];
+        };
+        RefreshTokenDto: {
+            /** @description 리프레시 토큰(Bearer 필요) */
+            refreshToken?: string;
+        };
+        ResponseDtoTokenInfoDto: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["TokenInfoDto"];
+        };
+        TokenInfoDto: {
+            /** @description 허가 타입(Bearer) */
+            grantType?: string;
+            /** @description 액세스 토큰 */
+            accessToken?: string;
+            /** @description 리프레시 토큰 */
+            refreshToken?: string;
+        };
+        IdTokenDto: {
+            idToken: string;
+        };
+        Info: {
+            title?: string;
+            /** @enum {string} */
+            type?: "RELATIONSHIP_RESPONSE" | "RELATIONSHIP_REQUEST" | "SCHEDULE_REMINDER" | "DIARY_CREATED" | "MEDICATION_REMINDER" | "RELEASED" | "ETC";
+            /** Format: int64 */
+            senderId?: number;
+            /** Format: int64 */
+            receiverId?: number;
+            body?: string;
+        };
+        ResponseDtoVoid: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: Record<string, never>;
+        };
+        DeviceToken: {
+            deviceToken?: string;
+        };
+        Base64ImageDto: {
+            base64Image?: string;
+        };
+        /** @description 내용 목록 */
+        DiaryContentDto: {
+            /**
+             * @description 일기 타입(QNA, FREE)
+             * @enum {string}
+             */
+            type?: "QNA" | "FREE";
+            /** @description 제목 */
+            title?: string;
+            /** @description 내용 */
+            content?: string;
+        };
+        DiaryRequestDto: {
+            /** @description 내용 목록 */
+            contents?: components["schemas"]["DiaryContentDto"][];
+            /** @description 날씨 */
+            weather?: string;
+            /** @description 감정상태(HAPPINESS,SADNESS,ANGER,ANXIETY,CALMNESS */
+            emotion?: string;
+            /** @description 오디오URL */
+            audioUrl?: string;
+            /** @description 사진 URL 목록 */
+            photos?: string[];
+            /** @description 공유여부 */
+            shared?: boolean;
+        };
+        Registration: {
+            relationship?: string;
+        };
+        CaregiverResponseDto: {
+            /** Format: int64 */
+            patientCaregiverId?: number;
+        };
+        ResponseDtoCaregiverResponseDto: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["CaregiverResponseDto"];
+        };
+        SignUp: {
+            /** @description 이름 */
+            name?: string;
+            /** @description 성별(MAN,WOMAN) */
+            gender?: string;
+            /** @description 전화번호 */
+            phone?: string;
+            /**
+             * @description 생년월일
+             * @example 1999.09.13
+             */
+            birthday?: string;
+            /** @description 프로필이미지 url */
+            profileImageUrl?: string;
+            /** @description 역할(PATIENT,CAREGIVER) */
+            role?: string;
+        };
+        Update: {
+            name?: string;
+            profile_image?: string;
+            phone?: string;
+            birthday?: string;
+            /** @enum {string} */
+            gender?: "MAN" | "WOMAN";
+        };
+        ResponseDtoInfo: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["Info"];
+        };
+        DistrictResponseDto: {
+            /** @description 행정구역 명칭 */
+            adm_nm?: string;
+            /** @description 행정구역 코드 */
+            adm_cd?: string;
+        };
+        ResponseDtoListDistrictResponseDto: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["DistrictResponseDto"][];
+        };
+        Detail: {
+            profileImageUrl?: string;
+            name?: string;
+            /** @enum {string} */
+            gender?: "MAN" | "WOMAN";
+            birthday?: string;
+            phoneNumber?: string;
+            location?: components["schemas"]["Location"];
+        };
+        Location: {
+            latitude?: string;
+            longitude?: string;
+        };
+        ResponseDtoDetail: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["Detail"];
+        };
+        NotificationResponseDto: {
+            /** Format: int64 */
+            id?: number;
+            title?: string;
+            /** @enum {string} */
+            type?: "RELATIONSHIP_RESPONSE" | "RELATIONSHIP_REQUEST" | "SCHEDULE_REMINDER" | "DIARY_CREATED" | "MEDICATION_REMINDER" | "RELEASED" | "ETC";
+            /** Format: int64 */
+            senderId?: number;
+            senderProfileImage?: string;
+            /** Format: int64 */
+            receiverId?: number;
+            body?: string;
+            /** Format: date-time */
+            createdAt?: string;
+            read?: boolean;
+        };
+        PageableObject: {
+            /** Format: int64 */
+            offset?: number;
+            sort?: components["schemas"]["SortObject"];
+            /** Format: int32 */
+            pageNumber?: number;
+            /** Format: int32 */
+            pageSize?: number;
+            paged?: boolean;
+            unpaged?: boolean;
+        };
+        ResponseDtoSliceNotificationResponseDto: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["SliceNotificationResponseDto"];
+        };
+        SliceNotificationResponseDto: {
+            /** Format: int32 */
+            size?: number;
+            content?: components["schemas"]["NotificationResponseDto"][];
+            /** Format: int32 */
+            number?: number;
+            sort?: components["schemas"]["SortObject"];
+            /** Format: int32 */
+            numberOfElements?: number;
+            pageable?: components["schemas"]["PageableObject"];
+            first?: boolean;
+            last?: boolean;
+            empty?: boolean;
+        };
+        SortObject: {
+            empty?: boolean;
+            sorted?: boolean;
+            unsorted?: boolean;
+        };
+        DistrictCoordinateResponseDto: {
+            /** @description 행정구역 명칭 */
+            admNm?: string;
+            /** @description 행정구역 코드 */
+            admCd?: string;
+            /** @description 행정구역 좌표 */
+            coordinate?: string;
+        };
+        ResponseDtoDistrictCoordinateResponseDto: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["DistrictCoordinateResponseDto"];
+        };
+        ContentDto: {
+            /** @enum {string} */
+            type?: "QNA" | "FREE";
+            title?: string;
+            content?: string;
+        };
+        DiaryDetailResponseDto: {
+            /** Format: int64 */
+            diaryId?: number;
+            /** Format: int64 */
+            patientId?: number;
+            contents?: components["schemas"]["ContentDto"][];
+            weather?: string;
+            /** @enum {string} */
+            emotion?: "HAPPINESS" | "SADNESS" | "ANGER" | "ANXIETY" | "CALMNESS";
+            photos?: string[];
+            /** Format: date-time */
+            createdAt?: string;
+        };
+        ResponseDtoDiaryDetailResponseDto: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["DiaryDetailResponseDto"];
+        };
+        Brief: {
+            /**
+             * Format: int64
+             * @description 일기 인덱스
+             */
+            diaryId?: number;
+            /**
+             * @description 감정상태(HAPPINESS,SADNESS,ANGER,ANXIETY,CALMNESS
+             * @enum {string}
+             */
+            emotion?: "HAPPINESS" | "SADNESS" | "ANGER" | "ANXIETY" | "CALMNESS";
+            /**
+             * Format: date-time
+             * @description 생성일자
+             */
+            createdAt?: string;
+        };
+        DiaryBriefResponseDto: {
+            /** Format: int64 */
+            patientId?: number;
+            briefs?: components["schemas"]["Brief"][];
+        };
+        ResponseDtoListDiaryBriefResponseDto: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["DiaryBriefResponseDto"][];
+        };
+        BriefDetail: {
+            /** Format: int64 */
+            patientId?: number;
+            profileImageUrl?: string;
+            name?: string;
+            relationship?: string;
+            accepted?: boolean;
+        };
+        ResponseDtoListBriefDetail: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["BriefDetail"][];
+        };
+        Id: {
+            /** Format: int64 */
+            caregiverId?: number;
+        };
+        ResponseDtoId: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["Id"];
+        };
+        ResponseDtoTokenAccountInfoDto: {
+            /** @enum {string} */
+            status?: "SUCCESS" | "FAILURE" | "ERROR";
+            message?: string;
+            data?: components["schemas"]["TokenAccountInfoDto"];
+        };
+        TokenAccountInfoDto: {
+            /**
+             * Format: int64
+             * @description 계정 인덱스
+             */
+            id?: number;
+            /** @description 이메일 */
+            email?: string;
+            /**
+             * @description 내용
+             * @enum {string}
+             */
+            provider?: "KAKAO" | "APPLE";
+            /** @description 프로필 이미지 url */
+            profile_image?: string;
+            /** @description 이름 */
+            name?: string;
+            /**
+             * Format: int32
+             * @description 나이
+             */
+            age?: number;
+            /** @description 전화번호 */
+            phone?: string;
+            /**
+             * @description 성별(MAN,WOMAN)
+             * @enum {string}
+             */
+            gender?: "MAN" | "WOMAN";
+            /** @description 생년월일 */
+            birthday?: string;
+            /** @description 역할(PATIENT,CAREGIVER */
+            role?: string;
+        };
     };
-    ResponseDtoLong: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      /** Format: int64 */
-      data?: number;
-    };
-    LocationRequestDto: {
-      latitude?: string;
-      longitude?: string;
-    };
-    ResponseDtoString: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: string;
-    };
-    Phone: {
-      phoneNumber?: string;
-    };
-    ResponseDtoListPhone: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['Phone'][];
-    };
-    RefreshTokenDto: {
-      /** @description 리프레시 토큰(Bearer 필요) */
-      refreshToken?: string;
-    };
-    ResponseDtoTokenInfoDto: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['TokenInfoDto'];
-    };
-    TokenInfoDto: {
-      /** @description 허가 타입(Bearer) */
-      grantType?: string;
-      /** @description 액세스 토큰 */
-      accessToken?: string;
-      /** @description 리프레시 토큰 */
-      refreshToken?: string;
-    };
-    IdTokenDto: {
-      idToken: string;
-    };
-    Info: {
-      title?: string;
-      /** @enum {string} */
-      type?:
-        | 'RELATIONSHIP_RESPONSE'
-        | 'RELATIONSHIP_REQUEST'
-        | 'SCHEDULE_REMINDER'
-        | 'DIARY_CREATED'
-        | 'MEDICATION_REMINDER'
-        | 'RELEASED'
-        | 'ETC';
-      /** Format: int64 */
-      senderId?: number;
-      /** Format: int64 */
-      receiverId?: number;
-      body?: string;
-    };
-    ResponseDtoVoid: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: Record<string, never>;
-    };
-    DeviceToken: {
-      deviceToken?: string;
-    };
-    Base64ImageDto: {
-      base64Image?: string;
-    };
-    /** @description 내용 목록 */
-    DiaryContentDto: {
-      /**
-       * @description 일기 타입(QNA, FREE)
-       * @enum {string}
-       */
-      type?: 'QNA' | 'FREE';
-      /** @description 제목 */
-      title?: string;
-      /** @description 내용 */
-      content?: string;
-    };
-    DiaryRequestDto: {
-      /** @description 내용 목록 */
-      contents?: components['schemas']['DiaryContentDto'][];
-      /** @description 날씨 */
-      weather?: string;
-      /** @description 감정상태(HAPPINESS,SADNESS,ANGER,ANXIETY,CALMNESS */
-      emotion?: string;
-      /** @description 오디오URL */
-      audioUrl?: string;
-      /** @description 사진 URL 목록 */
-      photos?: string[];
-      /** @description 공유여부 */
-      shared?: boolean;
-    };
-    Registration: {
-      relationship?: string;
-    };
-    CaregiverResponseDto: {
-      /** Format: int64 */
-      patientCaregiverId?: number;
-    };
-    ResponseDtoCaregiverResponseDto: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['CaregiverResponseDto'];
-    };
-    SignUp: {
-      /** @description 이름 */
-      name?: string;
-      /** @description 성별(MAN,WOMAN) */
-      gender?: string;
-      /** @description 전화번호 */
-      phone?: string;
-      /**
-       * @description 생년월일
-       * @example 1999.09.13
-       */
-      birthday?: string;
-      /** @description 프로필이미지 url */
-      profileImageUrl?: string;
-      /** @description 역할(PATIENT,CAREGIVER) */
-      role?: string;
-    };
-    Update: {
-      name?: string;
-      profile_image?: string;
-      phone?: string;
-      birthday?: string;
-      /** @enum {string} */
-      gender?: 'MAN' | 'WOMAN';
-    };
-    ResponseDtoInfo: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['Info'];
-    };
-    DistrictResponseDto: {
-      /** @description 행정구역 명칭 */
-      adm_nm?: string;
-      /** @description 행정구역 코드 */
-      adm_cd?: string;
-    };
-    ResponseDtoListDistrictResponseDto: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['DistrictResponseDto'][];
-    };
-    Detail: {
-      profileImageUrl?: string;
-      name?: string;
-      /** @enum {string} */
-      gender?: 'MAN' | 'WOMAN';
-      birthday?: string;
-      phoneNumber?: string;
-      location?: components['schemas']['Location'];
-    };
-    Location: {
-      latitude?: string;
-      longitude?: string;
-    };
-    ResponseDtoDetail: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['Detail'];
-    };
-    NotificationResponseDto: {
-      /** Format: int64 */
-      id?: number;
-      title?: string;
-      /** @enum {string} */
-      type?:
-        | 'RELATIONSHIP_RESPONSE'
-        | 'RELATIONSHIP_REQUEST'
-        | 'SCHEDULE_REMINDER'
-        | 'DIARY_CREATED'
-        | 'MEDICATION_REMINDER'
-        | 'RELEASED'
-        | 'ETC';
-      /** Format: int64 */
-      senderId?: number;
-      senderProfileImage?: string;
-      /** Format: int64 */
-      receiverId?: number;
-      body?: string;
-      /** Format: date-time */
-      createdAt?: string;
-      read?: boolean;
-    };
-    PageableObject: {
-      /** Format: int64 */
-      offset?: number;
-      sort?: components['schemas']['SortObject'];
-      /** Format: int32 */
-      pageNumber?: number;
-      /** Format: int32 */
-      pageSize?: number;
-      paged?: boolean;
-      unpaged?: boolean;
-    };
-    ResponseDtoSliceNotificationResponseDto: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['SliceNotificationResponseDto'];
-    };
-    SliceNotificationResponseDto: {
-      /** Format: int32 */
-      size?: number;
-      content?: components['schemas']['NotificationResponseDto'][];
-      /** Format: int32 */
-      number?: number;
-      sort?: components['schemas']['SortObject'];
-      /** Format: int32 */
-      numberOfElements?: number;
-      pageable?: components['schemas']['PageableObject'];
-      first?: boolean;
-      last?: boolean;
-      empty?: boolean;
-    };
-    SortObject: {
-      empty?: boolean;
-      unsorted?: boolean;
-      sorted?: boolean;
-    };
-    DistrictCoordinateResponseDto: {
-      /** @description 행정구역 명칭 */
-      admNm?: string;
-      /** @description 행정구역 코드 */
-      admCd?: string;
-      /** @description 행정구역 좌표 */
-      coordinate?: string;
-    };
-    ResponseDtoDistrictCoordinateResponseDto: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['DistrictCoordinateResponseDto'];
-    };
-    ContentDto: {
-      /** @enum {string} */
-      type?: 'QNA' | 'FREE';
-      title?: string;
-      content?: string;
-    };
-    DiaryDetailResponseDto: {
-      /** Format: int64 */
-      diaryId?: number;
-      /** Format: int64 */
-      patientId?: number;
-      contents?: components['schemas']['ContentDto'][];
-      weather?: string;
-      /** @enum {string} */
-      emotion?: 'HAPPINESS' | 'SADNESS' | 'ANGER' | 'ANXIETY' | 'CALMNESS';
-      photos?: string[];
-      /** Format: date-time */
-      createdAt?: string;
-    };
-    ResponseDtoDiaryDetailResponseDto: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['DiaryDetailResponseDto'];
-    };
-    Brief: {
-      /**
-       * Format: int64
-       * @description 일기 인덱스
-       */
-      diaryId?: number;
-      /**
-       * @description 감정상태(HAPPINESS,SADNESS,ANGER,ANXIETY,CALMNESS
-       * @enum {string}
-       */
-      emotion?: 'HAPPINESS' | 'SADNESS' | 'ANGER' | 'ANXIETY' | 'CALMNESS';
-      /**
-       * Format: date-time
-       * @description 생성일자
-       */
-      createdAt?: string;
-    };
-    DiaryBriefResponseDto: {
-      /** Format: int64 */
-      patientId?: number;
-      briefs?: components['schemas']['Brief'][];
-    };
-    ResponseDtoListDiaryBriefResponseDto: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['DiaryBriefResponseDto'][];
-    };
-    BriefDetail: {
-      /** Format: int64 */
-      patientId?: number;
-      profileImageUrl?: string;
-      name?: string;
-      relationship?: string;
-      accepted?: boolean;
-    };
-    ResponseDtoListBriefDetail: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['BriefDetail'][];
-    };
-    ResponseDtoTokenAccountInfoDto: {
-      /** @enum {string} */
-      status?: 'SUCCESS' | 'FAILURE' | 'ERROR';
-      message?: string;
-      data?: components['schemas']['TokenAccountInfoDto'];
-    };
-    TokenAccountInfoDto: {
-      /**
-       * Format: int64
-       * @description 계정 인덱스
-       */
-      id?: number;
-      /** @description 이메일 */
-      email?: string;
-      /**
-       * @description 내용
-       * @enum {string}
-       */
-      provider?: 'KAKAO' | 'APPLE';
-      /** @description 프로필 이미지 url */
-      profile_image?: string;
-      /** @description 이름 */
-      name?: string;
-      /**
-       * Format: int32
-       * @description 나이
-       */
-      age?: number;
-      /** @description 전화번호 */
-      phone?: string;
-      /**
-       * @description 성별(MAN,WOMAN)
-       * @enum {string}
-       */
-      gender?: 'MAN' | 'WOMAN';
-      /** @description 생년월일 */
-      birthday?: string;
-      /** @description 역할(PATIENT,CAREGIVER */
-      role?: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  findAllSafeZone: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        patientId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoListDistrictResponseDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  registerSafeZone: {
-    parameters: {
-      query: {
-        adm_cd: string;
-      };
-      header?: never;
-      path: {
-        patientId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoLong'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  savePatientLastLocation: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        patientId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LocationRequestDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoString'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  searchByPhone: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['Phone'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoListPhone'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  registerCaregiver: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        caregiverId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoLong'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  reGenerateAccessToken: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['RefreshTokenDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoTokenInfoDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  kakaoLogin: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['IdTokenDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoTokenInfoDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  appleLogin: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['IdTokenDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoTokenInfoDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getAllNotifications: {
-    parameters: {
-      query: {
-        pageNumber: number;
-        pageSize: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoSliceNotificationResponseDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  pushNotification: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['Info'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoVoid'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getDeviceToken: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['DeviceToken'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoString'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  uploadImage: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['Base64ImageDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoString'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  saveDiary: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['DiaryRequestDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoLong'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  registerCaregiver_1: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        patientId: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['Registration'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoCaregiverResponseDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  signUp: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['SignUp'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoString'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  deleteAccount: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': string;
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  updateUserInfo: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['Update'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoInfo'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  checkSafeZone: {
-    parameters: {
-      query: {
-        longitude: number;
-        latitude: number;
-      };
-      header?: never;
-      path: {
-        patientId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': string;
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getPatientDetail: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        patientId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoDetail'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  readNotification: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        notificationId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoString'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  searchDistricts: {
-    parameters: {
-      query: {
-        searchWord: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoListDistrictResponseDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  processGeoJson: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getDistrictCoordinate: {
-    parameters: {
-      query: {
-        adm_cd: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoDistrictCoordinateResponseDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  checkLocation: {
-    parameters: {
-      query: {
-        adm_cd: string;
-        longitude: number;
-        latitude: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': string;
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  findDiaryById: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        diaryId: number;
-        patientId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoDiaryDetailResponseDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  findAllDiary: {
-    parameters: {
-      query: {
-        month: number;
-        year: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoListDiaryBriefResponseDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getPatientsList: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoListBriefDetail'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  getUserInfo: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoTokenAccountInfoDto'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  deleteSafeZone: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        safeZoneId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoLong'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  deleteDiaryById: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        diaryId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ResponseDtoVoid'];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
+    findAllSafeZone: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                patientId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoListDistrictResponseDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    registerSafeZone: {
+        parameters: {
+            query: {
+                adm_cd: string;
+            };
+            header?: never;
+            path: {
+                patientId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoLong"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    savePatientLastLocation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                patientId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LocationRequestDto"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoString"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    searchByPhone: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Phone"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoListPhone"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    acceptCaregiverRegistration: {
+        parameters: {
+            query: {
+                status: string;
+            };
+            header?: never;
+            path: {
+                caregiverId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoLong"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    reGenerateAccessToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RefreshTokenDto"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoTokenInfoDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    kakaoLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IdTokenDto"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoTokenInfoDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    appleLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IdTokenDto"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoTokenInfoDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getAllNotifications: {
+        parameters: {
+            query: {
+                pageNumber: number;
+                pageSize: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoSliceNotificationResponseDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    pushNotification: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Info"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoVoid"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getDeviceToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeviceToken"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoString"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    uploadImage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Base64ImageDto"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoString"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    saveDiary: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DiaryRequestDto"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoLong"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    registerCaregiver: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                patientId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Registration"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoCaregiverResponseDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    signUp: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SignUp"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoString"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateUserInfo: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Update"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoInfo"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    checkSafeZone: {
+        parameters: {
+            query: {
+                longitude: number;
+                latitude: number;
+            };
+            header?: never;
+            path: {
+                patientId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getPatientDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                patientId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoDetail"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    readNotification: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                notificationId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoString"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    searchDistricts: {
+        parameters: {
+            query: {
+                searchWord: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoListDistrictResponseDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    processGeoJson: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getDistrictCoordinate: {
+        parameters: {
+            query: {
+                adm_cd: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoDistrictCoordinateResponseDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    checkLocation: {
+        parameters: {
+            query: {
+                adm_cd: string;
+                longitude: number;
+                latitude: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    findDiaryById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                diaryId: number;
+                patientId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoDiaryDetailResponseDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    findAllDiary: {
+        parameters: {
+            query: {
+                month: number;
+                year: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoListDiaryBriefResponseDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getPatientsList: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoListBriefDetail"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getCaregiverId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoId"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getUserInfo: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoTokenAccountInfoDto"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteSafeZone: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                safeZoneId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoLong"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteDiaryById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                diaryId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoVoid"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    deletePatient: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                patientId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResponseDtoString"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
 }

--- a/src/pages/PatientDetailPage/components/PatientInfoSkeleton.tsx
+++ b/src/pages/PatientDetailPage/components/PatientInfoSkeleton.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useRef } from 'react';
+import { View, StyleSheet, Animated } from 'react-native';
+import { FILLBOM_COLOR } from '@/constants/color';
+
+const PatientInfoSkeleton = () => {
+  const fadeAnim = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(fadeAnim, {
+          toValue: 1,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(fadeAnim, {
+          toValue: 0.3,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+      ]),
+    ).start();
+  }, [fadeAnim]);
+
+  const AnimatedView = Animated.createAnimatedComponent(View);
+
+  return (
+    <View style={styles.wrapper}>
+      <AnimatedView style={[styles.profileImage, { opacity: fadeAnim }]} />
+      <View style={styles.infoWrapper}>
+        <AnimatedView style={[styles.textLine, styles.nameLine, { opacity: fadeAnim }]} />
+        <AnimatedView style={[styles.textLine, styles.shortLine, { opacity: fadeAnim }]} />
+        <AnimatedView style={[styles.textLine, styles.mediumLine, { opacity: fadeAnim }]} />
+        <AnimatedView style={[styles.textLine, styles.longLine, { opacity: fadeAnim }]} />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    width: '100%',
+    height: 174,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    justifyContent: 'flex-start',
+    alignSelf: 'center',
+    borderRadius: 10,
+    backgroundColor: FILLBOM_COLOR.GRAY[100],
+    paddingVertical: 16,
+    paddingLeft: 20,
+    marginVertical: 12,
+    marginHorizontal: 20,
+  },
+  profileImage: {
+    width: 92,
+    height: 92,
+    borderRadius: 50,
+    backgroundColor: FILLBOM_COLOR.GRAY[300],
+  },
+  infoWrapper: {
+    width: '60%',
+    marginLeft: 16,
+    justifyContent: 'center',
+    gap: 10,
+  },
+  textLine: {
+    height: 18,
+    borderRadius: 4,
+    backgroundColor: FILLBOM_COLOR.GRAY[300],
+  },
+  nameLine: {
+    width: '80%',
+  },
+  shortLine: {
+    width: '40%',
+  },
+  mediumLine: {
+    width: '70%',
+  },
+  longLine: {
+    width: '90%',
+  },
+});
+
+export default PatientInfoSkeleton;

--- a/src/pages/PatientDetailPage/components/PatientLastPosition.tsx
+++ b/src/pages/PatientDetailPage/components/PatientLastPosition.tsx
@@ -2,9 +2,9 @@
 import { NaverMapMarkerOverlay, NaverMapView } from '@mj-studio/react-native-naver-map';
 import { useRef, useState } from 'react';
 import { Animated, Easing, Image, ImageBackground, Pressable, Text, View } from 'react-native';
-import patientLastPositionStyle from '../styles/patientLastPosition.style';
 import RefreshIconNormal from '@/assets/svgs/ico_refresh_normal.svg';
 import RefreshIconPressed from '@/assets/svgs/ico_refresh_pressed.svg';
+import patientLastPositionStyle from '../styles/patientLastPosition.style';
 
 interface IPatientLastPositionProps {
   location?: {

--- a/src/pages/PatientDetailPage/components/PatientLastPositionSkeleton.tsx
+++ b/src/pages/PatientDetailPage/components/PatientLastPositionSkeleton.tsx
@@ -1,0 +1,71 @@
+import React, { useRef, useEffect } from 'react';
+import { View, Animated, StyleSheet } from 'react-native';
+import patientLastPositionStyle from '../styles/patientLastPosition.style';
+import { FILLBOM_COLOR } from '@/constants/color';
+
+const PatientLastPositionSkeleton = () => {
+  const fadeAnim = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(fadeAnim, {
+          toValue: 1,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(fadeAnim, {
+          toValue: 0.3,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+      ]),
+    ).start();
+  }, [fadeAnim]);
+
+  const AnimatedView = Animated.createAnimatedComponent(View);
+
+  return (
+    // eslint-disable-next-line react-native/no-inline-styles
+    <View style={{ width: '100%', height: '100%' }}>
+      <View style={patientLastPositionStyle.lastLocationHeader}>
+        <AnimatedView style={[styles.lastLocationHeaderText, { opacity: fadeAnim }]} />
+        <AnimatedView style={[styles.refreshButton, { opacity: fadeAnim }]} />
+      </View>
+      <View style={[patientLastPositionStyle.mapContainer, { borderColor: FILLBOM_COLOR.GRAY[200] }]}>
+        <AnimatedView style={[styles.mapSkeleton, { opacity: fadeAnim }]} />
+        <View style={styles.markerContainer}></View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  refreshButton: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: FILLBOM_COLOR.GRAY[300],
+  },
+  mapSkeleton: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: FILLBOM_COLOR.GRAY[200],
+    position: 'absolute',
+  },
+  markerContainer: {
+    width: '100%',
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'absolute',
+  },
+  lastLocationHeaderText: {
+    width: 150,
+    height: 20,
+    backgroundColor: FILLBOM_COLOR.GRAY[300],
+    borderRadius: 8,
+  },
+});
+
+export default PatientLastPositionSkeleton;

--- a/src/pages/PatientDetailPage/hooks/useDeletePatient.ts
+++ b/src/pages/PatientDetailPage/hooks/useDeletePatient.ts
@@ -1,22 +1,26 @@
 import { useDeleteMutation } from '@/api/hooks';
 
 const useDeletePatient = (patientId: number) => {
-  const mutation = useDeleteMutation('/caregiver/patients/{patientId}', {
-    onSuccess: () => {
-      console.log('환자를 삭제했습니다.');
-    },
-  });
+  const mutation = useDeleteMutation('/caregiver/patients/{patientId}');
 
-  const deletePatient = () => {
-    mutation.mutate({
-      params: {
-        path: {
-          patientId: patientId,
+  const deletePatient = async () => {
+    try {
+      mutation.mutate({
+        params: {
+          path: {
+            patientId: patientId,
+          },
         },
-      },
-    });
+      });
+      return { isSuccess: true, isError: false, error: null };
+    } catch (e) {
+      return { isSuccess: false, error: e };
+    }
   };
 
-  return { deletePatient };
+  return {
+    deletePatient,
+    isLoading: mutation.isPending,
+  };
 };
 export default useDeletePatient;

--- a/src/pages/PatientDetailPage/hooks/useDeletePatient.ts
+++ b/src/pages/PatientDetailPage/hooks/useDeletePatient.ts
@@ -1,3 +1,22 @@
-/** @Todo
- * 환자 삭제 API 개발 시 구현
- */
+import { useDeleteMutation } from '@/api/hooks';
+
+const useDeletePatient = (patientId: number) => {
+  const mutation = useDeleteMutation('/caregiver/patients/{patientId}', {
+    onSuccess: () => {
+      console.log('환자를 삭제했습니다.');
+    },
+  });
+
+  const deletePatient = () => {
+    mutation.mutate({
+      params: {
+        path: {
+          patientId: patientId,
+        },
+      },
+    });
+  };
+
+  return { deletePatient };
+};
+export default useDeletePatient;

--- a/src/pages/PatientDetailPage/index.tsx
+++ b/src/pages/PatientDetailPage/index.tsx
@@ -13,7 +13,10 @@ import CMenu from '@/components/Menu';
 import { ToastMessage } from '@/components/ToastMessage';
 import { FILLBOM_COLOR } from '@/constants/color';
 import PatientInfoCard from './components/PatientInfoCard';
+import PatientInfoSkeleton from './components/PatientInfoSkeleton';
 import PatientLastPosition from './components/PatientLastPosition';
+import PatientLastPositionSkeleton from './components/PatientLastPositionSkeleton';
+import useDeletePatient from './hooks/useDeletePatient';
 import useGetPatientDetail from './hooks/useGetPatientDetail';
 import { indexStyle } from './styles/index.style';
 const PatientDetailPage = () => {
@@ -21,7 +24,9 @@ const PatientDetailPage = () => {
   const [visible, setVisible] = useState(false);
 
   const { patientId } = useLocalSearchParams();
-  const { data, refetch } = useGetPatientDetail(Number(patientId));
+  const { data: patientDetailData, refetch, isLoading } = useGetPatientDetail(Number(patientId));
+  const { deletePatient } = useDeletePatient(Number(patientId));
+
   const insets = useSafeAreaInsets();
   const { width } = Dimensions.get('window');
 
@@ -51,10 +56,10 @@ const PatientDetailPage = () => {
             confirmText="삭제"
             title={`환자 관리 리스트에서 \n 삭제하시겠습니까?`}
             onConfirm={() => {
-              // deletePatient API 연동
+              deletePatient();
               setIsRightMenuVisible(false);
               setVisible(false);
-              ToastMessage(`${data?.name}님이 환자 관리에서 삭제되었습니다.`, <IconResponse />);
+              ToastMessage(`${patientDetailData?.name}님이 환자 관리에서 삭제되었습니다.`, <IconResponse />);
             }}
             onCancel={() => {
               setVisible(false);
@@ -86,8 +91,16 @@ const PatientDetailPage = () => {
           />
         </Menu>
         <View style={{ width: '100%', height: '100%', paddingHorizontal: 20 }}>
-          <PatientInfoCard patientInfo={data} />
-          <PatientLastPosition onRefresh={refetch} location={data?.location} profileImageUrl={data?.profileImageUrl} />
+          {isLoading ? <PatientInfoSkeleton /> : <PatientInfoCard patientInfo={patientDetailData} />}
+          {isLoading ? (
+            <PatientLastPositionSkeleton />
+          ) : (
+            <PatientLastPosition
+              onRefresh={refetch}
+              location={patientDetailData?.location}
+              profileImageUrl={patientDetailData?.profileImageUrl}
+            />
+          )}
         </View>
       </SafeAreaView>
     </PaperProvider>

--- a/src/pages/PatientDetailPage/index.tsx
+++ b/src/pages/PatientDetailPage/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-native/no-inline-styles */
-import { useLocalSearchParams } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
-import { Dimensions, StyleSheet, View } from 'react-native';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
 import { Divider, Menu, PaperProvider } from 'react-native-paper';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import CloseNormal from '@/assets/svgs/ico_close_normal.svg';
@@ -55,11 +55,18 @@ const PatientDetailPage = () => {
             }}
             confirmText="삭제"
             title={`환자 관리 리스트에서 \n 삭제하시겠습니까?`}
-            onConfirm={() => {
-              deletePatient();
+            onConfirm={async () => {
+              const { isSuccess, error } = await deletePatient();
+
               setIsRightMenuVisible(false);
               setVisible(false);
-              ToastMessage(`${patientDetailData?.name}님이 환자 관리에서 삭제되었습니다.`, <IconResponse />);
+
+              if (isSuccess) {
+                ToastMessage(`${patientDetailData?.name}님이 환자 관리에서 삭제되었습니다.`, <IconResponse />);
+                router.replace('/(auth)/caregiver/(tabs)/managePatient');
+              } else {
+                ToastMessage(`삭제에 실패했습니다. ${error?.message ?? error}`, <Text>❗️</Text>);
+              }
             }}
             onCancel={() => {
               setVisible(false);

--- a/src/pages/RefreshPage/index.tsx
+++ b/src/pages/RefreshPage/index.tsx
@@ -1,7 +1,7 @@
 import { router } from 'expo-router';
 import { useEffect } from 'react';
 import { View } from 'react-native';
-import { client, setHeaderAccessTokenNull } from '@/api/client';
+import { client } from '@/api/client';
 import Loading from '@/components/Loading';
 import { useAuthStore } from '@/stores/authStore';
 import { styles } from './styles';
@@ -10,7 +10,6 @@ const RefreshPage = () => {
   const { initState, refreshToken, setState } = useAuthStore();
 
   const refresh = async () => {
-    setHeaderAccessTokenNull();
     try {
       if (!refreshToken) {
         throw new Error('refreshToken is not found');

--- a/src/pages/RefreshPage/index.tsx
+++ b/src/pages/RefreshPage/index.tsx
@@ -1,7 +1,7 @@
 import { router } from 'expo-router';
 import { useEffect } from 'react';
 import { View } from 'react-native';
-import { client, setAccessToken } from '@/api/client';
+import { client, setHeaderAccessTokenNull } from '@/api/client';
 import Loading from '@/components/Loading';
 import { useAuthStore } from '@/stores/authStore';
 import { styles } from './styles';
@@ -10,15 +10,16 @@ const RefreshPage = () => {
   const { initState, refreshToken, setState } = useAuthStore();
 
   const refresh = async () => {
+    setHeaderAccessTokenNull();
     try {
       if (!refreshToken) {
         throw new Error('refreshToken is not found');
       }
-      setAccessToken(null);
       const data = (await client.POST('/oauth/refresh-token', { body: { refreshToken: refreshToken! } })).data;
       if (data?.data) {
         setState('accessToken', data.data.accessToken);
         setState('refreshToken', data.data.refreshToken);
+        router.back();
       }
     } catch (error) {
       initState();


### PR DESCRIPTION
## Motivation

기능 설명과 개발 동기에 대해서는 티켓을 확인해주세요.

https://onehunnit.atlassian.net/browse/OK-23

<br>

## Key Changes

주요 변경사항을 요약하면 다음과 같습니다.

- 환자 삭제 성공, 실패시에 따라 토스트 메시지가 다르게 뜨도록 구현하였습니다.
- 환자 상세페이지 스켈레톤을 구현하였습니다.
- AccessToken 갱신 요청 시 authStore의 accessToken을 undefined로 만들고, 헤더에 Authorization을 삭제하도록 로직을 개선하였습니다.

![feat(OK-23) 회원삭제](https://github.com/user-attachments/assets/2ffafc6d-647b-4083-8c32-01788cf13dc6)

![feat(OK-23) 환자 상세 스켈레톤](https://github.com/user-attachments/assets/1aa04b0b-f4ee-4844-85b7-bf40cf46f7af)
![feat(OK-23) 삭제 실패](https://github.com/user-attachments/assets/309a533c-9694-4a28-9c76-e76d21c714d8)

<br>

## To Reviewers

-
